### PR TITLE
Mods to CSRF Functions

### DIFF
--- a/cf10.cfm
+++ b/cf10.cfm
@@ -143,22 +143,22 @@
 </cffunction>
 
 <cffunction name="CsrfGenerateToken" output="false" returntype="string">
-  <cfargument name="key" type="string" required="false" default="" />
-  <cfargument name="random" type="string" required="false" default="false" />
+  <cfargument name="key" type="string" required="false" default="_cfbackportcsrfdefaultkey" />
+  <cfargument name="forceNew" type="boolean" required="false" default="false" />
   <cfscript>
     var lc = StructNew();
     // TODO: Session locking?
     if (Not StructKeyExists(session, '_cfbackportcsrf')) {
       session['_cfbackportcsrf'] = StructNew();
     }
-    if (arguments.random Or Not StructKeyExists(session._cfbackportcsrf, arguments.key)) {
+    if (arguments.forceNew Or Not StructKeyExists(session._cfbackportcsrf, arguments.key)) {
       lc.token = Now();
       // Throw in the datetime for a little more randomisation
       lc.times = 3;
       // Combinations = 65536^lc.times
       // e.g. 65536^3 = 281,474,976,710,656 possible values to pick from
       // This should be secure enough as the value is either per
-      // generation (random=true) or only lives for the session lifetime
+      // generation (forceNew=true) or only lives for the session lifetime
       for (lc.i = 1; lc.i Lte lc.times; lc.i = lc.i + 1) {
         lc.token = lc.token & RandRange(0, 65535, "SHA1PRNG");
       }
@@ -174,7 +174,7 @@
 
 <cffunction name="CsrfVerifyToken" output="false" returntype="boolean">
   <cfargument name="token" type="string" required="true" />
-  <cfargument name="key" type="string" required="false" default="" />
+  <cfargument name="key" type="string" required="false" default="_cfbackportcsrfdefaultkey" />
   <cfscript>
     // TODO: Session locking?
     if (StructKeyExists(session, '_cfbackportcsrf')


### PR DESCRIPTION
Making csrfGenerateToken function signature match Adobe's.
Giving csrf\* functions' "key" arguments a less-strange default value.
