### PR TITLE
CF11 QueryExecute for CF10 or below

### DIFF
--- a/cf11.cfm
+++ b/cf11.cfm
@@ -3,7 +3,7 @@
 	<cfargument name="queryParams"  default="#structNew()#">
 	<cfargument name="queryOptions" default="#structNew()#">
 
-	<cfset arguments.parameters = []>
+	<cfset var parameters = []>
 	
 	<cfif isArray(queryParams)>
 		<cfloop array="#queryParams#" index="local.param">

--- a/cf11.cfm
+++ b/cf11.cfm
@@ -1,0 +1,29 @@
+﻿<cffunction name="QueryExecute" output="false" returntype="query">
+	<cfargument name="sql_statement" required="true">
+	<cfargument name="queryParams"  default="#structNew()#">
+	<cfargument name="queryOptions" default="#structNew()#">
+
+	<cfset arguments.parameters = []>
+	
+	<cfif isArray(queryParams)>
+		<cfloop array="#queryParams#" index="local.param">
+			<cfif isSimpleValue(param)>
+				<cfset arrayAppend(parameters, {value=param})>
+			<cfelse>
+				<cfset arrayAppend(parameters, param)>
+			</cfif>
+		</cfloop>
+	<cfelseif isStruct(queryParams)>
+		<cfloop collection="#queryParams#" item="local.key">
+			<cfif isSimpleValue(queryParams[key])>
+				<cfset arrayAppend(parameters, {name=local.key, value=queryParams[key]})>
+			<cfelse>
+				<cfset arrayAppend(parameters, queryParams[key])>
+			</cfif>
+		</cfloop>
+	<cfelse>
+		<cfthrow message="unexpected type for queryParams">
+	</cfif>
+	
+	<cfreturn new Query(sql=sql_statement, parameters=parameters, argumentCollection=queryOptions).execute().getResult()>
+</cffunction>

--- a/cfbackport.cfm
+++ b/cfbackport.cfm
@@ -10,4 +10,7 @@
 	<cfif cfbackport.major lt 10>
 		<cfinclude template="cf10.cfm" />
 	</cfif>
+	<cfif cfbackport.major lt 11>
+		<cfinclude template="cf11.cfm" />
+	</cfif>
 </cfsilent>


### PR DESCRIPTION
Thin adapter for QueryExecute as documented at: http://blogs.coldfusion.com/post.cfm/language-enhancements-in-coldfusion-splendor-cf-functions-for-query-tag using Query.cfc in CF9 and above.  Does not support CF8.
