### PR TITLE
Add support for returning Prefix if defined

### DIFF
--- a/cf11.cfm
+++ b/cf11.cfm
@@ -1,7 +1,9 @@
 ﻿<!--- CF11 functions for CF9+ --->
 
 <cffunction name="QueryExecute" output="false" returntype="query"
-			hint="https://wikidocs.adobe.com/wiki/display/coldfusionen/QueryExecute">
+			hint="
+				* result struct is returned to the caller by utilizing URL scope (no prefix needed) * 
+				https://wikidocs.adobe.com/wiki/display/coldfusionen/QueryExecute">
 	<cfargument name="sql_statement" required="true">
 	<cfargument name="queryParams"  default="#structNew()#">
 	<cfargument name="queryOptions" default="#structNew()#">
@@ -27,8 +29,20 @@
 	<cfelse>
 		<cfthrow message="unexpected type for queryParams">
 	</cfif>
+
+	<cfif structKeyExists(queryOptions, "result")>
+		<!--- strip scope, not supported --->
+		<cfset queryOptions.result = listLast(queryOptions.result, '.')>
+	</cfif>
 	
-	<cfreturn new Query(sql=sql_statement, parameters=parameters, argumentCollection=queryOptions).execute().getResult()>
+	<cfset var executeResult = new Query(sql=sql_statement, parameters=parameters, argumentCollection=queryOptions).execute()>
+	
+	<cfif structKeyExists(queryOptions, "result")>
+		<!--- workaround for passing result struct value out to the caller by utilizing URL scope (no prefix needed) --->
+		<cfset URL[queryOptions.result] = executeResult.getPrefix()>
+	</cfif>
+	
+	<cfreturn executeResult.getResult()>
 </cffunction>
 
 

--- a/cf11.cfm
+++ b/cf11.cfm
@@ -23,7 +23,9 @@
 			<cfif isSimpleValue(queryParams[key])>
 				<cfset arrayAppend(parameters, {name=local.key, value=queryParams[key]})>
 			<cfelse>
-				<cfset arrayAppend(parameters, queryParams[key])>
+				<cfset var parameter = {name=key}>
+				<cfset structAppend(parameter, queryParams[key])>
+				<cfset arrayAppend(parameters, parameter)>
 			</cfif>
 		</cfloop>
 	<cfelse>


### PR DESCRIPTION
Return via URL scope as workaround.  Limitation: cannot use 'local.foo' in queryOption.result
